### PR TITLE
Implement `unify` derivation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
+## v1.1.0 - 2024-02-21
+
+- [syntax] convert to `//$ derive DERIVATION OPT1 OPT2` `derive` syntax
+- [feature] `unify` derivation
+- [internal] addition of `ModuleReader` to `GenFunc`
+- [fix] make `util.snake_case` convert final capital (e.g. `FooB`) properly
+
 ## v1.0.1 - 2024-02-04
 
-- Downcase `uuid.to_string` on JSON encode
+- [fix] Downcase `uuid.to_string` on JSON encode
 
 ## v1.0.0 - 2025-02-03
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ gleam add deriv@1
 
 ## Usage
 
+### `derive json`
+
 ```gleam
 import youid/uuid.{type Uuid}
 
@@ -136,8 +138,66 @@ pub fn encode_post(value: Post) -> Json {
 }
 ```
 
-Further documentation can be found at <https://hexdocs.pm/deriv>.
+### `derive unify`
 
+```gleam
+// src/project/types/person.gleam
+pub type Person {
+  Person(
+    id: Int,
+    first_name: String,
+    last_name: String,
+    age: Int
+  )
+}
+```
+```gleam
+// src/project/types/pet.gleam
+pub type Pet {
+  Pet(
+    id: Int,
+    name: String,
+  )
+}
+```
+```gleam
+// src/project/types/friend.gleam
+import project/types/person.{type Person}
+import project/types/pet.{type Pet}
+
+pub type Friend {
+  //$ derive unify project/types/person.Person
+  //$ derive unify project/types/pet.Pet
+  Friend(
+    id: Int,
+    name: String,
+  )
+}
+```
+```
+$ gleam run -m deriv
+```
+```gleam
+import project/types/person.{type Person}
+import project/types/pet.{type Pet}
+
+pub type Friend {
+  //$ derive unify project/types/person.Person
+  //$ derive unify project/types/pet.Pet
+  Friend(
+    name: String,
+    //$ unify field project/types/person.Person first_name
+  )
+}
+
+pub fn person(value: Person) -> Friend {
+  Friend(name: value.first_name)
+}
+
+pub fn pet(value: Pet) -> Friend {
+  Friend(name: value.name)
+}
+```
 ## Development
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -13,12 +13,12 @@ gleam add deriv@1
 import youid/uuid.{type Uuid}
 
 pub type User {
-  //$ derive json(decode,encode)
+  //$ derive json decode encode
   User(id: Uuid, name: String)
 }
 
 pub type Post {
-  //$ derive json(decode,encode)
+  //$ derive json decode encode
   Post(
     id: Uuid,
     title: String,
@@ -45,12 +45,12 @@ import gleam/list
 import youid/uuid.{type Uuid}
 
 pub type User {
-  //$ derive json(decode,encode)
+  //$ derive json decode encode
   User(id: Uuid, name: String)
 }
 
 pub type Post {
-  //$ derive json(decode,encode)
+  //$ derive json decode encode
   Post(
     id: Uuid,
     title: String,

--- a/gleam.toml
+++ b/gleam.toml
@@ -1,5 +1,5 @@
 name = "deriv"
-version = "1.0.1"
+version = "1.1.0"
 description = "Derive functions for your Gleam types"
 licences = ["MIT"]
 repository = { type = "github", user = "bchase", repo = "deriv" }

--- a/src/deriv.gleam
+++ b/src/deriv.gleam
@@ -9,9 +9,10 @@ import gleam/regexp
 import simplifile
 import shellout
 import tom
-import deriv/types.{type File, File, type Output, Output, OutputInline, type Write, Write, type GenFunc, type Gen, Gen, type Derivation, Derivation, type DerivFieldOpts}
+import deriv/types.{type File, File, type Output, Output, OutputInline, type Write, Write, type GenFunc, type Gen, Gen, type Derivation, Derivation, type DerivFieldOpts, type ModuleReader}
 import deriv/parser
 import deriv/json as deriv_json
+import deriv/unify as deriv_unify
 import deriv/util
 import gleam/io
 
@@ -63,6 +64,7 @@ import gleam/io
 const all_gen_funcs: List(#(String, GenFunc)) =
   [
     #("json", deriv_json.gen),
+    #("unify", deriv_unify.gen),
   ]
 
 pub fn main() {
@@ -82,7 +84,7 @@ pub fn main() {
 
   filepaths
   |> load_files
-  |> gen_derivs
+  |> gen_derivs(util.fetch_module)
   |> build_writes
   |> perform_file_writes
 }
@@ -114,7 +116,10 @@ fn project_name() -> String {
   }
 }
 
-pub fn gen_derivs(files: List(File)) -> List(Gen) {
+pub fn gen_derivs(
+  files: List(File),
+  module_reader: ModuleReader,
+) -> List(Gen) {
   let gen_funcs = all_gen_funcs |>  dict.from_list
 
   let project_derivs_module_name = project_name() <> "/derivs"
@@ -129,7 +134,7 @@ pub fn gen_derivs(files: List(File)) -> List(Gen) {
 
       file
       |> parse_types_and_derivations
-      |> list.flat_map(gen_type_derivs(_, file, gen_funcs))
+      |> list.flat_map(gen_type_derivs(_, file, gen_funcs, module_reader))
     })
     |> list.flatten
     |> list.map(fn(gen) {
@@ -189,6 +194,7 @@ fn gen_type_derivs(
   x: #(CustomType, List(Derivation), DerivFieldOpts),
   file: File,
   gen_funcs: Dict(String, GenFunc),
+  module_reader: ModuleReader,
 ) -> List(Gen) {
   let #(type_, derivs, field_opts) = x
 
@@ -197,7 +203,7 @@ fn gen_type_derivs(
     case dict.get(gen_funcs, d.name) {
       Error(_) -> Error(Nil)
       Ok(f) -> {
-        Ok(f(type_, d, field_opts, file, util.fetch_custom_type))
+        Ok(f(type_, d, field_opts, file, module_reader))
       }
     }
   })
@@ -557,7 +563,7 @@ fn derivs_file_import_gens(
     let #(file, types_and_derivs) = load_types_from_file(import_, derivs, all_files)
 
     types_and_derivs
-    |> list.flat_map(gen_type_derivs(_, file, gen_funcs))
+    |> list.flat_map(gen_type_derivs(_, file, gen_funcs, util.fetch_module))
   })
 }
 

--- a/src/deriv.gleam
+++ b/src/deriv.gleam
@@ -197,7 +197,7 @@ fn gen_type_derivs(
     case dict.get(gen_funcs, d.name) {
       Error(_) -> Error(Nil)
       Ok(f) -> {
-        Ok(f(type_, d, field_opts, file))
+        Ok(f(type_, d, field_opts, file, util.fetch_custom_type))
       }
     }
   })

--- a/src/deriv/json.gleam
+++ b/src/deriv/json.gleam
@@ -13,7 +13,7 @@ pub fn gen(
   deriv: Derivation,
   field_opts: DerivFieldOpts,
   file: File,
-  module_reader: ModuleReader,
+  _module_reader: ModuleReader,
 ) -> Gen {
   let opts = deriv.opts
 

--- a/src/deriv/json.gleam
+++ b/src/deriv/json.gleam
@@ -5,10 +5,16 @@ import gleam/list
 import gleam/string
 import gleam/io
 import glance.{type CustomType, type Variant, type VariantField, LabelledVariantField, UnlabelledVariantField, NamedType, type Import, Import, UnqualifiedImport, Definition, CustomType, Public, Variant, Function, FieldAccess, Variable, Span, Expression, Call, UnlabelledField, Block, Use, BinaryOperator, Pipe, PatternVariable, ShorthandField, String, FunctionParameter, Tuple, Named, List, type Definition, type Function, type Span, type Expression, type Statement, type Type, Clause, Case, PatternAssignment, PatternConstructor, Fn, FnParameter}
-import deriv/types.{type File, type Derivation, type DerivFieldOpt, File, type Gen, Gen, type DerivFieldOpts}
+import deriv/types.{type File, type Derivation, type DerivFieldOpt, File, type Gen, Gen, type DerivFieldOpts, type ModuleReader}
 import deriv/util.{type BirlTimeKind, BirlTimeISO8601, BirlTimeUnixMicro, BirlTimeUnixMilli, BirlTimeUnix, BirlTimeHTTP, BirlTimeNaive}
 
-pub fn gen(type_: CustomType, deriv: Derivation, field_opts: DerivFieldOpts, file: File) -> Gen {
+pub fn gen(
+  type_: CustomType,
+  deriv: Derivation,
+  field_opts: DerivFieldOpts,
+  file: File,
+  module_reader: ModuleReader,
+) -> Gen {
   let opts = deriv.opts
 
   let gen_funcs_for_opts =

--- a/src/deriv/parser.gleam
+++ b/src/deriv/parser.gleam
@@ -67,6 +67,7 @@ fn parse_derivations_from_inside_type_def_lines(lines: List(String)) -> List(Der
     }
   })
   |> list.flatten
+  |> list.reverse
 }
 
 pub fn parse_import_with_derivations(import_: glance.Import, src: String) -> Result(#(glance.Import, List(Derivation)), Nil) {

--- a/src/deriv/parser.gleam
+++ b/src/deriv/parser.gleam
@@ -1,4 +1,5 @@
 import gleam/option.{type Option, Some, None}
+import gleam/io
 import gleam/dict
 import gleam/result
 import gleam/list
@@ -90,32 +91,16 @@ pub fn parse_import_with_derivations(import_: glance.Import, src: String) -> Res
 }
 
 fn parse_derivations(raw: String) -> Result(List(Derivation), Nil) {
-  let assert Ok(re) = regexp.from_string("((\\w+)[(]([^)]+)[)]\\s*)+")
+  raw
+  |> string.trim
+  |> string.split(" ")
+  |> fn(tokens) {
+    case tokens {
+      ["derive", name, ..opts] ->
+        Ok([Derivation(name:, opts:)])
 
-  let raw = string.trim(raw)
-
-  case string.starts_with(raw, "derive") {
-    False -> Error(Nil)
-    True -> {
-      let str =
-        raw
-        |> string.drop_start(6)
-        |> string.trim
-
-      string.split(str, " ")
-      |> list.map(fn(d) {
-        case regexp.scan(re, d) {
-          [Match(submatches: [_, Some(deriv), Some(opts_str)], ..)] -> {
-            let opts = string.split(opts_str, ",")
-
-            Ok(Derivation(name: deriv, opts:))
-          }
-
-          _ ->
-            panic as { "Parse failure on derivation: " <> d }
-        }
-      })
-      |> result.all
+      _ ->
+        Error(Nil)
     }
   }
 }

--- a/src/deriv/types.gleam
+++ b/src/deriv/types.gleam
@@ -1,10 +1,16 @@
 import gleam/option.{type Option}
 import gleam/dict.{type Dict}
 import glance.{type Module, type CustomType, type Import, type Definition}
+import simplifile
 
-pub type GenFunc = fn(CustomType, Derivation, DerivFieldOpts, File) -> Gen
+pub type GenFunc = fn(CustomType, Derivation, DerivFieldOpts, File, ModuleReader) -> Gen
 
-pub type ModuleReader = fn(String) -> Result(Module, Nil)
+pub type ModuleReaderErr {
+  FileErr(simplifile.FileError)
+  GlanceError(glance.Error)
+}
+
+pub type ModuleReader = fn(String) -> Result(Module, ModuleReaderErr)
 
 pub type File {
   File(

--- a/src/deriv/types.gleam
+++ b/src/deriv/types.gleam
@@ -7,7 +7,9 @@ pub type GenFunc = fn(CustomType, Derivation, DerivFieldOpts, File, ModuleReader
 
 pub type ModuleReaderErr {
   FileErr(simplifile.FileError)
-  GlanceError(glance.Error)
+  GlanceErr(glance.Error)
+  BadIdent(ident: String)
+  CustomTypeMissingErr(ident: String)
 }
 
 pub type ModuleReader = fn(String) -> Result(Module, ModuleReaderErr)

--- a/src/deriv/types.gleam
+++ b/src/deriv/types.gleam
@@ -1,8 +1,10 @@
 import gleam/option.{type Option}
 import gleam/dict.{type Dict}
-import glance.{type CustomType, type Import, type Definition}
+import glance.{type Module, type CustomType, type Import, type Definition}
 
 pub type GenFunc = fn(CustomType, Derivation, DerivFieldOpts, File) -> Gen
+
+pub type ModuleReader = fn(String) -> Result(Module, Nil)
 
 pub type File {
   File(

--- a/src/deriv/unify.gleam
+++ b/src/deriv/unify.gleam
@@ -1,0 +1,387 @@
+import gleam/dict
+import gleam/io
+import gleam/option.{Some, None}
+import gleam/list
+import gleam/result
+import gleam/string
+import glance.{type CustomType, type Definition, type Function, type Variant, LabelledVariantField, Definition, Function, Public, FunctionParameter, Named, NamedType, Expression, Call, Variable, LabelledField, FieldAccess, Span}
+import deriv/types.{type File, type Derivation, type Gen, Gen, type DerivFieldOpts, type ModuleReader, type DerivFieldOpt, type DerivField, DerivFieldOpt}
+import deriv/util
+
+pub type GenFunc = fn(CustomType, Derivation, DerivFieldOpts, File) -> Gen
+
+pub fn gen(
+  type_: CustomType,
+  deriv: Derivation,
+  field_opts: DerivFieldOpts,
+  file: File,
+  module_reader: ModuleReader,
+) -> Gen {
+  let overrides = build_field_overrides(field_opts, module_reader)
+
+  let idents = deriv.opts
+
+  let imports = []
+
+  let funcs =
+    unify(
+      type_,
+      idents,
+      overrides,
+      module_reader,
+    )
+    |> list.map(unify_func)
+
+  let src =
+    funcs
+    |> list.map(util.func_str)
+    |> string.join("\n\n")
+
+  Gen(file:, deriv:, imports:, funcs:, src:, meta: dict.new())
+}
+
+fn build_field_overrides(
+  field_opts: DerivFieldOpts,
+  module_reader: ModuleReader,
+) -> UnifyFieldOverrides {
+  field_opts
+  |> dict.map_values(fn(field, opts) {
+    opts
+    |> list.map(build_field_override(_, field, module_reader))
+  })
+  |> dict.to_list
+}
+
+type UnifyFunc {
+  UnifyFunc(
+    func_name: String,
+    param_type: String,
+    return_type: String,
+    return_contr: String,
+    fields: List(Field),
+  )
+}
+// func_name: String, // "authe_type_a"
+// param_type: String, // "AutheTypeA"
+// return_type: String, // "AutheTokens"
+// return_contr: String, // "Authe"
+// fields: List(#(String, String)),
+// // [
+// //   #("id", "authe_id"),
+// //   #("encrypted_access_token", "encrypted_access_token"),
+// //   #("encrypted_refresh_token", "encrypted_refresh_token"),
+// // ]
+
+fn get_param_types_and_variants(
+  idents: List(String),
+  module_reader: ModuleReader,
+) -> List(#(Definition(CustomType), Variant)) {
+  idents
+  |> list.map(fn(ident) {
+    util.fetch_custom_type(ident, module_reader)
+  })
+  |> result.all
+  |> fn(x) {
+    case x {
+      Error(err) -> {
+        io.debug(idents)
+        io.debug(err)
+        panic as "`unify` issue with the above `idents`"
+      }
+
+      Ok(list) ->
+        list
+    }
+  }
+  |> list.map(fn(x) {
+    let #(_module_name, type_) = x
+
+    case type_.definition.variants {
+      [variant] ->
+        #(type_, variant)
+
+      _, -> {
+        io.debug(type_)
+        panic as "`unify` derivation currently only supports invariant types"
+      }
+    }
+  })
+}
+
+fn unify(
+  return_type: CustomType,
+  idents: List(String),
+  overrides: UnifyFieldOverrides,
+  module_reader: ModuleReader,
+) -> List(UnifyFunc) {
+  case return_type.variants {
+    [return_variant] ->
+      idents
+      |> get_param_types_and_variants(module_reader)
+      |> list.map(fn(x) {
+        let #(param_type_def, param_variant) = x
+        let param_type = param_type_def.definition
+
+        unify_variant(
+          param_type,
+          param_variant,
+          return_type,
+          return_variant,
+          overrides,
+        )
+      })
+
+    _, -> {
+      io.debug(return_type)
+      panic as "`unify` derivation currently only supports invariant types"
+    }
+  }
+}
+
+fn unify_variant(
+  param_type: CustomType,
+  param_variant: Variant,
+  return_type: CustomType,
+  return_variant: Variant,
+  overrides: UnifyFieldOverrides,
+) -> UnifyFunc {
+  let fields = unify_func_fields(
+    param_type,
+    param_variant,
+    return_type,
+    return_variant,
+    overrides,
+  )
+
+  let func_name = util.snake_case(param_type.name)
+  let param_type = param_type.name
+  let return_type = return_type.name
+  let return_contr = return_variant.name
+
+  UnifyFunc(
+    func_name:,
+    param_type:,
+    return_type:,
+    return_contr:,
+    fields:,
+  )
+}
+
+// fn unify_func_fields(
+//   param_variant: Variant,
+//   return_variant: Variant,
+//   overrides: UnifyFieldOverrides,
+// ) -> List(Field) {
+//   return_variant.fields
+//   |> list.map(fn(f1) {
+//     // #(f1.item, list.find(param_variant.field, fn(f2) { f1.name == f2.name}))
+//   })
+// }
+
+type Field {
+  Field(
+    // type_: String,
+    // param_field_override: Option(String),
+    param_field: String,
+    return_field: String,
+  )
+}
+
+type UnifyFieldOverrides = List(#(DerivField, List(UnifyFieldOverride)))
+
+type UnifyFieldOverride {
+  UnifyFieldOverride(
+    ident: String,
+    field: String,
+    override: String,
+    module_name: String,
+    type_: CustomType,
+  )
+}
+
+fn build_field_override(
+  field_opt: DerivFieldOpt,
+  deriv_field: DerivField,
+  module_reader: ModuleReader,
+) -> UnifyFieldOverride {
+  case field_opt {
+    DerivFieldOpt(strs: ["unify", "field", ident, override]) -> {
+      let #(module_name, type_) =
+        case util.fetch_custom_type(ident, module_reader) {
+          Error(err) -> {
+            io.debug(err)
+            panic
+          }
+
+          Ok(#(m, td)) -> #(m, td.definition)
+        }
+
+      let field = deriv_field.field
+
+      UnifyFieldOverride(
+        ident:,
+        field:,
+        override:,
+        module_name:,
+        type_:,
+      )
+    }
+
+    _ -> {
+      io.debug(field_opt)
+      panic as "Invalid `unify` `DerivFieldOpt` (printed above)"
+    }
+  }
+}
+
+// fn field_overrides(
+//   ident: String,
+//   field_name: String,
+//   overrides: UnifyFieldOverrides,
+// ) -> Option(String) {
+//   overrides
+//   |> list.find_map(fn(x) {
+//     let #(f, opts) = x
+//     case f.field == field_name {
+//       False ->
+//         Error(Nil)
+
+//       True -> {
+//         list.find_map(opts, fn(opt) {
+//           case opt {
+//             UnifyFieldOverride(override:, ..) as uf -> {
+//               case uf.ident == ident {
+//                 False -> Error(Nil)
+//                 True -> Ok(override)
+//               }
+//             }
+//           }
+//         })
+//       }
+//     }
+//   })
+//   |> option.from_result
+// }
+
+fn unify_func_fields(
+  param_type: CustomType,
+  param_variant: Variant,
+  return_type: CustomType,
+  return_variant: Variant,
+  overrides: UnifyFieldOverrides,
+) -> List(Field) {
+  let param_fields = fields(param_variant)
+  let return_fields = fields(return_variant)
+
+  return_fields
+  |> list.map(fn(r_field) {
+    let #(return_field, result_field_type) = r_field
+
+    let overrides =
+      overrides
+      |> list.filter_map(fn(x) {
+        let #(df, os) = x
+
+        case df.type_ == return_type.name && df.field == return_field {
+          False -> Error(Nil)
+          True -> Ok(#(df.field, os))
+        }
+      })
+
+    let override =
+      overrides
+      |> list.find_map(fn(x) {
+        let #(param_field, os) = x
+
+        list.find_map(os, fn(o) {
+          case o.field == return_field {
+            False -> Error(Nil)
+            True -> Ok(#(param_field, o))
+          }
+        })
+      })
+
+    let #(param_field, _p_type) =
+      case override {
+        Error(_) -> #(return_field, Nil)
+        Ok(#(_param_field, o)) -> #(o.override, Nil)
+      }
+
+    let param_field_type =
+      list.find_map(param_fields, fn(x) {
+        let #(name, type_) = x
+        case param_field == name {
+          False -> Error(Nil)
+          True -> Ok(type_)
+        }
+      })
+
+    case param_field_type {
+      Error(_) -> {
+        io.debug(param_type)
+        io.debug(param_variant)
+        io.debug(param_field)
+        panic as "`unify` param field doesn't exist"
+      }
+
+      Ok(param_field_type) if param_field_type == result_field_type ->
+        param_field_type
+
+      _ -> {
+        io.println("PARAM TYPE")
+        io.debug(param_type)
+        io.debug(param_variant)
+        io.debug(param_field)
+        io.println("RETURN TYPE")
+        io.debug(return_type)
+        io.debug(return_variant)
+        io.debug(return_field)
+        panic as "`unify` param & return field types don't match"
+      }
+    }
+
+    Field(
+      // param_field_override:,
+      param_field:,
+      return_field:,
+    )
+  })
+}
+
+fn fields(variant: Variant) -> List(#(String, String)) {
+  variant.fields
+  |> list.map(fn(field) {
+    case field {
+      LabelledVariantField(item: NamedType(name:, ..), label:) ->
+        #(label, name)
+
+      _ -> {
+        io.debug(variant)
+        io.debug(field)
+        panic as "Only the following field type is supported: `LabelledVariantField(item: NamedType(name:, ..), label:)`"
+      }
+    }
+  })
+}
+
+fn unify_func(
+  uf: UnifyFunc
+) -> Definition(Function) {
+  let UnifyFunc(
+    func_name:,
+    param_type:,
+    return_type:,
+    return_contr:,
+    fields:,
+  ) = uf
+
+  let dummy_span = Span(-1, -1)
+
+  Definition([], Function(func_name, Public,
+    [FunctionParameter(None, Named("value"), Some(NamedType(param_type, None, [])))],
+    Some(NamedType(return_type, None, [])),
+    [Expression(Call(Variable(return_contr), list.map(fields, fn(field) {
+      LabelledField(field.return_field, FieldAccess(Variable("value"), field.param_field))
+    })))], dummy_span)
+  )
+}

--- a/src/deriv/util.gleam
+++ b/src/deriv/util.gleam
@@ -9,8 +9,9 @@ import youid/uuid.{type Uuid}
 import glance.{type Module, type Definition, type Function, Module, Definition, Function, type CustomType, type Variant}
 import glance_printer
 import shellout
+import simplifile
 import birl.{type Time}
-import deriv/types.{type DerivFieldOpts, type DerivFieldOpt, DerivField, type ModuleReader}
+import deriv/types.{type DerivFieldOpts, type DerivFieldOpt, DerivField, type ModuleReader, type ModuleReaderErr}
 import gleam/io
 
 pub fn decode_type_field(
@@ -399,5 +400,10 @@ pub fn birl_time_kind(
   }
 }
 
-pub fn fetch_custom_type(ident: String, module_reader: ModuleReader) -> Result(Module, Nil) {
+pub fn fetch_custom_type(ident: String) -> Result(Module, ModuleReaderErr) {
+  let filepath = "src/" <> ident <> ".gleam"
+  use src <- result.try(simplifile.read(filepath) |> result.map_error(types.FileErr))
+  use src <- result.try(glance.module(src) |> result.map_error(types.GlanceError))
+
+  Ok(src)
 }

--- a/src/deriv/util.gleam
+++ b/src/deriv/util.gleam
@@ -68,13 +68,30 @@ pub fn snake_case(str: String) -> String {
   |> list.reverse
   |> list.fold(SC(acc: [], curr: [], next_is_capital: True), step_snake_case)
   |> fn(sc) {
-    let result =
-      case sc.curr {
-        [] -> sc.acc
-        _ -> list.append(sc.acc, [sc.curr])
-      }
+    case sc.curr {
+      [] -> sc
+      _ -> SC(..sc, acc: list.append(sc.acc, [sc.curr]))
+    }
+    |> fn(sc) {
+      case sc.acc {
+        [[last, second_to_last, ..rest], ..rest_chunks] -> {
+          let last_is_uppercase = last == string.uppercase(last)
+          let second_to_last_is_lowercase = second_to_last == string.lowercase(second_to_last)
 
-    result
+          case last_is_uppercase && second_to_last_is_lowercase {
+            False -> sc.acc
+            True -> {
+              let second_to_last_chunk = [second_to_last, ..rest]
+              let last_chunk = [last]
+
+              [last_chunk, second_to_last_chunk, ..rest_chunks]
+            }
+          }
+        }
+
+        _ -> sc.acc
+      }
+    }
     |> list.map(fn(group) {
       group
       |> list.reverse
@@ -400,10 +417,37 @@ pub fn birl_time_kind(
   }
 }
 
-pub fn fetch_custom_type(ident: String) -> Result(Module, ModuleReaderErr) {
-  let filepath = "src/" <> ident <> ".gleam"
+pub fn fetch_module(path: String) -> Result(Module, ModuleReaderErr) {
+  let filepath = "src/" <> path <> ".gleam"
   use src <- result.try(simplifile.read(filepath) |> result.map_error(types.FileErr))
-  use src <- result.try(glance.module(src) |> result.map_error(types.GlanceError))
+  use module <- result.try(glance.module(src) |> result.map_error(types.GlanceErr))
 
-  Ok(src)
+  Ok(module)
+}
+
+pub fn fetch_custom_type(
+  ident: String,
+  read_module: ModuleReader,
+) -> Result(#(String, glance.Definition(glance.CustomType)), ModuleReaderErr) {
+  use #(module_name, ref) <- result.try(parse_ident(ident))
+  use module <- result.try(read_module(module_name))
+  use type_ <- result.try(find_custom_type(ref, module))
+
+  Ok(#(module_name, type_))
+}
+
+fn parse_ident(ident: String) -> Result(#(String, String), ModuleReaderErr) {
+  case string.split(ident, ".") {
+    [a, b] -> Ok(#(a, b))
+    _ -> Error(types.BadIdent(ident))
+  }
+}
+
+fn find_custom_type(
+  ref: String,
+  module: glance.Module,
+) -> Result(glance.Definition(glance.CustomType), ModuleReaderErr) {
+  module.custom_types
+  |> list.find(fn(type_) { type_.definition.name == ref })
+  |> result.replace_error(types.CustomTypeMissingErr(ref))
 }

--- a/src/deriv/util.gleam
+++ b/src/deriv/util.gleam
@@ -6,11 +6,11 @@ import gleam/result
 import gleam/regexp.{type Regexp}
 import decode.{type Decoder}
 import youid/uuid.{type Uuid}
-import glance.{type Definition, type Function, Module, Definition, Function, type CustomType, type Variant}
+import glance.{type Module, type Definition, type Function, Module, Definition, Function, type CustomType, type Variant}
 import glance_printer
 import shellout
 import birl.{type Time}
-import deriv/types.{type DerivFieldOpts, type DerivFieldOpt, DerivField}
+import deriv/types.{type DerivFieldOpts, type DerivFieldOpt, DerivField, type ModuleReader}
 import gleam/io
 
 pub fn decode_type_field(
@@ -397,4 +397,7 @@ pub fn birl_time_kind(
         }
       }
   }
+}
+
+pub fn fetch_custom_type(ident: String, module_reader: ModuleReader) -> Result(Module, Nil) {
 }

--- a/test/deriv_test.gleam
+++ b/test/deriv_test.gleam
@@ -32,7 +32,7 @@ pub fn json_test() {
 import youid/uuid.{type Uuid}
 
 pub type Foo {
-  //$ derive json(decode,encode)
+  //$ derive json decode encode
   Foo(
     uuid: Uuid,
     id: Int, //$ json named int_id
@@ -44,7 +44,7 @@ pub type Foo {
 }
 
 pub type Bar {
-  //$ derive json(decode)
+  //$ derive json decode
   Bar(
     baz: Bool,
   )
@@ -60,7 +60,7 @@ import gleam/list
 import youid/uuid.{type Uuid}
 
 pub type Foo {
-  //$ derive json(decode,encode)
+  //$ derive json decode encode
   Foo(
     uuid: Uuid,
     id: Int, //$ json named int_id
@@ -72,7 +72,7 @@ pub type Foo {
 }
 
 pub type Bar {
-  //$ derive json(decode)
+  //$ derive json decode
   Bar(
     baz: Bool,
   )
@@ -188,7 +188,7 @@ pub fn json_multi_variant_type_test() {
   // |> string.trim
   let input = "
 pub type T {
-  //$ derive json(decode,encode)
+  //$ derive json decode encode
   X(foo: String)
   Y(bar: Int)
 }
@@ -200,7 +200,7 @@ import decode.{type Decoder}
 import gleam/json.{type Json}
 
 pub type T {
-  //$ derive json(decode,encode)
+  //$ derive json decode encode
   X(foo: String)
   Y(bar: Int)
 }
@@ -260,7 +260,7 @@ pub fn encode_t(value: T) -> Json {
 pub fn json_optional_field_test() {
   let input = "
 pub type Maybe {
-  //$ derive json(decode,encode)
+  //$ derive json decode encode
   Maybe(
     name: Option(String),
   )
@@ -273,7 +273,7 @@ import decode.{type Decoder}
 import gleam/json.{type Json}
 
 pub type Maybe {
-  //$ derive json(decode,encode)
+  //$ derive json decode encode
   Maybe(
     name: Option(String),
   )
@@ -330,7 +330,7 @@ pub fn gleam_format_magic_comment_parsing_test() {
   // //$ json(baz(boo))
   let src = "
 pub type T {
-  //$ derive json(decode)
+  //$ derive json decode
   A(
     foo: String,
     //$ json foo bar
@@ -365,14 +365,14 @@ pub type T {
 pub fn nested_type_test() {
   let input = "
 pub type A {
-  //$ derive json(decode,encode)
+  //$ derive json decode encode
   A(
     b: B,
   )
 }
 
 pub type B {
-  //$ derive json(decode,encode)
+  //$ derive json decode encode
   B(
     x: String,
   )
@@ -385,14 +385,14 @@ import decode.{type Decoder}
 import gleam/json.{type Json}
 
 pub type A {
-  //$ derive json(decode,encode)
+  //$ derive json decode encode
   A(
     b: B,
   )
 }
 
 pub type B {
-  //$ derive json(decode,encode)
+  //$ derive json decode encode
   B(
     x: String,
   )
@@ -624,7 +624,7 @@ pub fn birl_json_test() {
 import birl.{type Time}
 
 pub type DateTimeExamples {
-  //$ derive json(decode,encode)
+  //$ derive json decode encode
   DateTimeExamples(
     t0: Time,
     t1: Time, //$ json birl iso8601
@@ -644,7 +644,7 @@ import deriv/util
 import gleam/json.{type Json}
 
 pub type DateTimeExamples {
-  //$ derive json(decode,encode)
+  //$ derive json decode encode
   DateTimeExamples(
     t0: Time,
     t1: Time, //$ json birl iso8601
@@ -734,7 +734,7 @@ pub fn encode_date_time_examples(value: DateTimeExamples) -> Json {
 pub fn dict_fields_json_test() {
   let input = string.trim("
 pub type DictFieldType {
-  //$ derive json(decode,encode)
+  //$ derive json decode encode
   DictFieldType(
     dict: Dict(String, Int),
   )
@@ -746,7 +746,7 @@ import decode.{type Decoder}
 import gleam/json.{type Json}
 
 pub type DictFieldType {
-  //$ derive json(decode,encode)
+  //$ derive json decode encode
   DictFieldType(
     dict: Dict(String, Int),
   )
@@ -811,7 +811,7 @@ pub fn encode_dict_field_type(value: DictFieldType) -> Json {
 pub fn unnested_json_test() {
   let input = "
 pub type Unnested {
-  //$ derive json(decode,encode)
+  //$ derive json decode encode
   Unnested(
     unnested: Int, //$ json named foo.bar.baz
   )
@@ -824,7 +824,7 @@ import decode.{type Decoder}
 import gleam/json.{type Json}
 
 pub type Unnested {
-  //$ derive json(decode,encode)
+  //$ derive json decode encode
   Unnested(
     unnested: Int, //$ json named foo.bar.baz
   )
@@ -956,7 +956,8 @@ pub type AutheB {
 
   let input = "
 pub type AutheTokens {
-  //$ derive unify(project/authe/a.AutheA,project/authe/b.AutheB)
+  //$ derive unify project/authe/a.AutheA
+  //$ derive unify project/authe/b.AutheB
   Authe(
     id: Uuid,
     //$ unify field project/authe/a.AutheA authe_id
@@ -969,7 +970,8 @@ pub type AutheTokens {
 
  let output = "
 pub type AutheTokens {
-  //$ derive unify(project/authe/a.AutheA,project/authe/b.AutheB)
+  //$ derive unify project/authe/a.AutheA
+  //$ derive unify project/authe/b.AutheB
   Authe(
     id: Uuid,
     //$ unify field project/authe/a.AutheA authe_id
@@ -979,7 +981,7 @@ pub type AutheTokens {
   )
 }
 
-pub fn authe_a(value: AutheA) -> AutheTokens {
+pub fn authe_b(value: AutheB) -> AutheTokens {
   Authe(
     id: value.authe_id,
     encrypted_access_token: value.encrypted_access_token,
@@ -987,7 +989,7 @@ pub fn authe_a(value: AutheA) -> AutheTokens {
   )
 }
 
-pub fn authe_b(value: AutheB) -> AutheTokens {
+pub fn authe_a(value: AutheA) -> AutheTokens {
   Authe(
     id: value.authe_id,
     encrypted_access_token: value.encrypted_access_token,

--- a/test/deriv_test.gleam
+++ b/test/deriv_test.gleam
@@ -9,7 +9,9 @@ import deriv/parser
 import deriv
 import deriv/util
 import gleam/io
+import deriv/example/unify
 
+import simplifile
 import glance.{Import, UnqualifiedImport, Named}
 
 pub fn suppress_io_warnings() { io.debug(Nil) }
@@ -865,3 +867,86 @@ pub fn encode_unnested(value: Unnested) -> Json {
   write.src
   |> should.equal(output)
 }
+
+// pub fn a_unnested_json_test() {
+//   let assert Ok(module) = simplifile.read("")
+
+//   let input = "
+// pub type Unnested {
+//   Unnested(
+//     unnested: Int, //$ json named foo.bar.baz
+//   )
+// } //$ derive json(decode,encode)
+//   "
+//   |> string.trim
+
+//  let output = "
+// import decode.{type Decoder}
+// import gleam/json.{type Json}
+
+// pub type Unnested {
+//   Unnested(
+//     unnested: Int, //$ json named foo.bar.baz
+//   )
+// } //$ derive json(decode,encode)
+
+// pub fn decoder_unnested() -> Decoder(Unnested) {
+//   decode.one_of([decoder_unnested_unnested()])
+// }
+
+// pub fn decoder_unnested_unnested() -> Decoder(Unnested) {
+//   decode.into({
+//     use unnested <- decode.parameter
+//     Unnested(unnested:)
+//   })
+//   |> decode.subfield([\"foo\", \"bar\", \"baz\"], decode.int)
+// }
+
+// pub fn encode_unnested(value: Unnested) -> Json {
+//   case value {
+//     Unnested(..) as value ->
+//       json.object([
+//         #(
+//           \"foo\",
+//           json.object([
+//             #(\"bar\", json.object([#(\"baz\", json.int(value.unnested))])),
+//           ]),
+//         ),
+//       ])
+//   }
+// }
+//   "
+//   |> string.trim
+
+//   let files = [ File(module: "deriv/example/foo", src: input, idx: Some(1)) ]
+
+//   let assert [write] =
+//     files
+//     |> deriv.gen_derivs
+//     |> deriv.build_writes
+
+//   let files = [ File(module: "deriv/example/foo", src: write.src, idx: Some(1)) ]
+
+//   let writes =
+//     files
+//     |> deriv.gen_derivs
+//     |> deriv.build_writes
+
+//   let assert [write] =
+//     writes
+
+//   io.println("")
+//   io.println("")
+//   io.println("GENERATED")
+//   io.println(write.src)
+//   io.println("")
+//   io.println("")
+//   io.println("EXPECTED")
+//   io.println(output)
+
+//   write.filepath
+//   |> should.equal("src/deriv/example/foo.gleam")
+
+//   write.src
+//   |> should.equal(output)
+// }

--- a/test/deriv_test.gleam
+++ b/test/deriv_test.gleam
@@ -868,85 +868,85 @@ pub fn encode_unnested(value: Unnested) -> Json {
   |> should.equal(output)
 }
 
-// pub fn a_unnested_json_test() {
-//   let assert Ok(module) = simplifile.read("")
+pub fn a_unnested_json_test() {
+  let assert Ok(module) = simplifile.read("")
 
-//   let input = "
-// pub type Unnested {
-//   Unnested(
-//     unnested: Int, //$ json named foo.bar.baz
-//   )
-// } //$ derive json(decode,encode)
-//   "
-//   |> string.trim
+  let input = "
+pub type Unnested {
+  Unnested(
+    unnested: Int, //$ json named foo.bar.baz
+  )
+} //$ derive json(decode,encode)
+  "
+  |> string.trim
 
-//  let output = "
-// import decode.{type Decoder}
-// import gleam/json.{type Json}
+ let output = "
+import decode.{type Decoder}
+import gleam/json.{type Json}
 
-// pub type Unnested {
-//   Unnested(
-//     unnested: Int, //$ json named foo.bar.baz
-//   )
-// } //$ derive json(decode,encode)
+pub type Unnested {
+  Unnested(
+    unnested: Int, //$ json named foo.bar.baz
+  )
+} //$ derive json(decode,encode)
 
-// pub fn decoder_unnested() -> Decoder(Unnested) {
-//   decode.one_of([decoder_unnested_unnested()])
-// }
+pub fn decoder_unnested() -> Decoder(Unnested) {
+  decode.one_of([decoder_unnested_unnested()])
+}
 
-// pub fn decoder_unnested_unnested() -> Decoder(Unnested) {
-//   decode.into({
-//     use unnested <- decode.parameter
-//     Unnested(unnested:)
-//   })
-//   |> decode.subfield([\"foo\", \"bar\", \"baz\"], decode.int)
-// }
+pub fn decoder_unnested_unnested() -> Decoder(Unnested) {
+  decode.into({
+    use unnested <- decode.parameter
+    Unnested(unnested:)
+  })
+  |> decode.subfield([\"foo\", \"bar\", \"baz\"], decode.int)
+}
 
-// pub fn encode_unnested(value: Unnested) -> Json {
-//   case value {
-//     Unnested(..) as value ->
-//       json.object([
-//         #(
-//           \"foo\",
-//           json.object([
-//             #(\"bar\", json.object([#(\"baz\", json.int(value.unnested))])),
-//           ]),
-//         ),
-//       ])
-//   }
-// }
-//   "
-//   |> string.trim
+pub fn encode_unnested(value: Unnested) -> Json {
+  case value {
+    Unnested(..) as value ->
+      json.object([
+        #(
+          \"foo\",
+          json.object([
+            #(\"bar\", json.object([#(\"baz\", json.int(value.unnested))])),
+          ]),
+        ),
+      ])
+  }
+}
+  "
+  |> string.trim
 
-//   let files = [ File(module: "deriv/example/foo", src: input, idx: Some(1)) ]
+  let files = [ File(module: "deriv/example/foo", src: input, idx: Some(1)) ]
 
-//   let assert [write] =
-//     files
-//     |> deriv.gen_derivs
-//     |> deriv.build_writes
+  let assert [write] =
+    files
+    |> deriv.gen_derivs
+    |> deriv.build_writes
 
-//   let files = [ File(module: "deriv/example/foo", src: write.src, idx: Some(1)) ]
+  let files = [ File(module: "deriv/example/foo", src: write.src, idx: Some(1)) ]
 
-//   let writes =
-//     files
-//     |> deriv.gen_derivs
-//     |> deriv.build_writes
+  let writes =
+    files
+    |> deriv.gen_derivs
+    |> deriv.build_writes
 
-//   let assert [write] =
-//     writes
+  let assert [write] =
+    writes
 
-//   io.println("")
-//   io.println("")
-//   io.println("GENERATED")
-//   io.println(write.src)
-//   io.println("")
-//   io.println("")
-//   io.println("EXPECTED")
-//   io.println(output)
+  io.println("")
+  io.println("")
+  io.println("GENERATED")
+  io.println(write.src)
+  io.println("")
+  io.println("")
+  io.println("EXPECTED")
+  io.println(output)
 
-//   write.filepath
-//   |> should.equal("src/deriv/example/foo.gleam")
+  write.filepath
+  |> should.equal("src/deriv/example/foo.gleam")
 
-//   write.src
-//   |> should.equal(output)
-// }
+  write.src
+  |> should.equal(output)
+}

--- a/test/deriv_test.gleam
+++ b/test/deriv_test.gleam
@@ -32,6 +32,7 @@ pub fn json_test() {
 import youid/uuid.{type Uuid}
 
 pub type Foo {
+  //$ derive json(decode,encode)
   Foo(
     uuid: Uuid,
     id: Int, //$ json named int_id
@@ -40,13 +41,14 @@ pub type Foo {
     ratio: Float,
     words: List(String),
   )
-} //$ derive json(decode,encode)
+}
 
 pub type Bar {
+  //$ derive json(decode)
   Bar(
     baz: Bool,
   )
-} //$ derive json(decode)
+}
   "
   |> string.trim
 
@@ -58,6 +60,7 @@ import gleam/list
 import youid/uuid.{type Uuid}
 
 pub type Foo {
+  //$ derive json(decode,encode)
   Foo(
     uuid: Uuid,
     id: Int, //$ json named int_id
@@ -66,13 +69,14 @@ pub type Foo {
     ratio: Float,
     words: List(String),
   )
-} //$ derive json(decode,encode)
+}
 
 pub type Bar {
+  //$ derive json(decode)
   Bar(
     baz: Bool,
   )
-} //$ derive json(decode)
+}
 
 pub fn decoder_foo() -> Decoder(Foo) {
   decode.one_of([decoder_foo_foo()])
@@ -184,9 +188,10 @@ pub fn json_multi_variant_type_test() {
   // |> string.trim
   let input = "
 pub type T {
+  //$ derive json(decode,encode)
   X(foo: String)
   Y(bar: Int)
-} //$ derive json(decode,encode)
+}
   "
   |> string.trim
 
@@ -195,9 +200,10 @@ import decode.{type Decoder}
 import gleam/json.{type Json}
 
 pub type T {
+  //$ derive json(decode,encode)
   X(foo: String)
   Y(bar: Int)
-} //$ derive json(decode,encode)
+}
 
 pub fn decoder_t() -> Decoder(T) {
   decode.one_of([decoder_t_x(), decoder_t_y()])
@@ -254,10 +260,11 @@ pub fn encode_t(value: T) -> Json {
 pub fn json_optional_field_test() {
   let input = "
 pub type Maybe {
+  //$ derive json(decode,encode)
   Maybe(
     name: Option(String),
   )
-} //$ derive json(decode,encode)
+}
   "
   |> string.trim
 
@@ -266,10 +273,11 @@ import decode.{type Decoder}
 import gleam/json.{type Json}
 
 pub type Maybe {
+  //$ derive json(decode,encode)
   Maybe(
     name: Option(String),
   )
-} //$ derive json(decode,encode)
+}
 
 pub fn decoder_maybe() -> Decoder(Maybe) {
   decode.one_of([decoder_maybe_maybe()])
@@ -357,16 +365,18 @@ pub type T {
 pub fn nested_type_test() {
   let input = "
 pub type A {
+  //$ derive json(decode,encode)
   A(
     b: B,
   )
-} //$ derive json(decode,encode)
+}
 
 pub type B {
+  //$ derive json(decode,encode)
   B(
     x: String,
   )
-} //$ derive json(decode,encode)
+}
   "
   |> string.trim
 
@@ -375,16 +385,18 @@ import decode.{type Decoder}
 import gleam/json.{type Json}
 
 pub type A {
+  //$ derive json(decode,encode)
   A(
     b: B,
   )
-} //$ derive json(decode,encode)
+}
 
 pub type B {
+  //$ derive json(decode,encode)
   B(
     x: String,
   )
-} //$ derive json(decode,encode)
+}
 
 pub fn decoder_a() -> Decoder(A) {
   decode.one_of([decoder_a_a()])
@@ -612,6 +624,7 @@ pub fn birl_json_test() {
 import birl.{type Time}
 
 pub type DateTimeExamples {
+  //$ derive json(decode,encode)
   DateTimeExamples(
     t0: Time,
     t1: Time, //$ json birl iso8601
@@ -621,7 +634,7 @@ pub type DateTimeExamples {
     t5: Time, //$ json birl unix_milli
     t6: Time, //$ json birl unix_micro
   )
-} //$ derive json(decode,encode)
+}
 ")
 
   let output = string.trim("
@@ -631,6 +644,7 @@ import deriv/util
 import gleam/json.{type Json}
 
 pub type DateTimeExamples {
+  //$ derive json(decode,encode)
   DateTimeExamples(
     t0: Time,
     t1: Time, //$ json birl iso8601
@@ -640,7 +654,7 @@ pub type DateTimeExamples {
     t5: Time, //$ json birl unix_milli
     t6: Time, //$ json birl unix_micro
   )
-} //$ derive json(decode,encode)
+}
 
 pub fn decoder_date_time_examples() -> Decoder(DateTimeExamples) {
   decode.one_of([decoder_date_time_examples_date_time_examples()])
@@ -720,10 +734,11 @@ pub fn encode_date_time_examples(value: DateTimeExamples) -> Json {
 pub fn dict_fields_json_test() {
   let input = string.trim("
 pub type DictFieldType {
+  //$ derive json(decode,encode)
   DictFieldType(
     dict: Dict(String, Int),
   )
-} //$ derive json(decode,encode)
+}
 ")
 
   let output = string.trim("
@@ -731,10 +746,11 @@ import decode.{type Decoder}
 import gleam/json.{type Json}
 
 pub type DictFieldType {
+  //$ derive json(decode,encode)
   DictFieldType(
     dict: Dict(String, Int),
   )
-} //$ derive json(decode,encode)
+}
 
 pub fn decoder_dict_field_type() -> Decoder(DictFieldType) {
   decode.one_of([decoder_dict_field_type_dict_field_type()])
@@ -795,10 +811,11 @@ pub fn encode_dict_field_type(value: DictFieldType) -> Json {
 pub fn unnested_json_test() {
   let input = "
 pub type Unnested {
+  //$ derive json(decode,encode)
   Unnested(
     unnested: Int, //$ json named foo.bar.baz
   )
-} //$ derive json(decode,encode)
+}
   "
   |> string.trim
 
@@ -807,10 +824,11 @@ import decode.{type Decoder}
 import gleam/json.{type Json}
 
 pub type Unnested {
+  //$ derive json(decode,encode)
   Unnested(
     unnested: Int, //$ json named foo.bar.baz
   )
-} //$ derive json(decode,encode)
+}
 
 pub fn decoder_unnested() -> Decoder(Unnested) {
   decode.one_of([decoder_unnested_unnested()])

--- a/test/deriv_test.gleam
+++ b/test/deriv_test.gleam
@@ -981,7 +981,7 @@ pub type AutheTokens {
   )
 }
 
-pub fn authe_b(value: AutheB) -> AutheTokens {
+pub fn authe_a(value: AutheA) -> AutheTokens {
   Authe(
     id: value.authe_id,
     encrypted_access_token: value.encrypted_access_token,
@@ -989,7 +989,7 @@ pub fn authe_b(value: AutheB) -> AutheTokens {
   )
 }
 
-pub fn authe_a(value: AutheA) -> AutheTokens {
+pub fn authe_b(value: AutheB) -> AutheTokens {
   Authe(
     id: value.authe_id,
     encrypted_access_token: value.encrypted_access_token,
@@ -1097,12 +1097,12 @@ pub type Friend {
   )
 }
 
-pub fn pet(value: Pet) -> Friend {
-  Friend(name: value.name)
-}
-
 pub fn person(value: Person) -> Friend {
   Friend(name: value.first_name)
+}
+
+pub fn pet(value: Pet) -> Friend {
+  Friend(name: value.name)
 }
   "
   |> string.trim


### PR DESCRIPTION
- **start `ModuleReader` to look up type in other file**
- **impl `fetch_custom_type` & use `ModuleReader`**
- **impl module/type lookups; fix `snake_case`**
- **pass `ModuleReader` during code gen**
- **impl `unify` derivation**
- **make `derive` usage consistent in tests**
- **change `derive` magic comment syntax**
- **add `Friend` `unify` test**
- **fix `unify` override lookup**
- **fix derivs order to go top-to-bototm**
- **add `unify` example to README**
- **bump version to `1.1.0` and update CHANGELOG**
